### PR TITLE
Add fuzzers and enable fuzzing in CI.

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcr.io/oss-fuzz-base/base-builder:v1
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+COPY . $SRC/app-radix
+WORKDIR app-radix/fuzz
+COPY .clusterfuzzlite/build.sh $SRC/

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -eu
+
+# build fuzzers
+./build.sh
+cp cmake-build-fuzz/fuzz_* $OUT

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,49 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  pull_request:
+    paths:
+      - '**'
+  workflow_dispatch:
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer:
+        - address
+        # Override this with the sanitizers you want.
+        # - undefined
+        # - memory
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        language: c
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to only run fuzzers that are affected
+        # by the PR.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 60
+        mode: 'code-change'
+        sanitizer: ${{ matrix.sanitizer }}
+        # Optional but recommended: used to download the corpus produced by
+        # batch fuzzing.
+        # See later section on "Git repo for storage".
+        # storage-repo: https://${{ secrets.PERSONAL_ACCESS_TOKEN }}@github.com/OWNER/STORAGE-REPO-NAME.git
+        # storage-repo-branch: main   # Optional. Defaults to "main"
+        # storage-repo-branch-coverage: gh-pages  # Optional. Defaults to "gh-pages".

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.4)
+
+project(Fuzzer LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+
+add_compile_options(-g -ggdb2 -O3)
+
+set(RADIX_DIR "../src")
+set(UTIL_DIR "../unit-tests/util")
+
+add_compile_definitions(APPNETWORK=1)
+
+# Build with code coverage generation
+if(CODE_COVERAGE)
+    if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
+        add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+        add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+    elseif(CMAKE_C_COMPILER_ID MATCHES "GNU")
+        add_compile_options(-fprofile-arcs -ftest-coverage)
+        link_libraries(gcov)
+    else()
+        message(FATAL_ERROR "Unsupported compiler used with code coverage generation")
+    endif()
+endif()
+
+add_library(radix
+    ${RADIX_DIR}/common/read.c
+    ${RADIX_DIR}/common/bech32_encode.c
+    ${RADIX_DIR}/instruction/instruction.c
+    ${RADIX_DIR}/instruction/substate/substate.c
+    ${RADIX_DIR}/instruction/substate/substate_type.c
+    ${RADIX_DIR}/instruction/substate/substate_id.c
+    ${RADIX_DIR}/instruction/substate/tokens.c
+    ${RADIX_DIR}/instruction/instruction_type.c
+    ${RADIX_DIR}/instruction/substate/validator_allow_delegation_flag.c
+    ${RADIX_DIR}/instruction/substate/validator_owner_copy.c
+    ${RADIX_DIR}/instruction/substate/prepared_unstake.c
+    ${RADIX_DIR}/instruction/substate/prepared_stake.c
+    ${RADIX_DIR}/instruction/substate/stake_ownership.c
+    ${RADIX_DIR}/instruction/substate/substate.c
+    ${RADIX_DIR}/transaction/transaction.c
+    ${RADIX_DIR}/transaction/transaction_parser.c
+    ${RADIX_DIR}/types/bip32_path.c
+    ${RADIX_DIR}/types/buffer.c
+    ${RADIX_DIR}/types/hasher.c
+    ${RADIX_DIR}/types/public_key.c
+    ${RADIX_DIR}/types/re_address.c
+    ${RADIX_DIR}/types/re_address_type.c
+    ${RADIX_DIR}/types/re_bytes.c
+    ${RADIX_DIR}/types/uint256.c
+    ${UTIL_DIR}/sha256.c
+)
+
+add_executable(fuzz_tx_parser fuzz_tx_parser.c)
+add_executable(fuzz_bip32_path fuzz_bip32_path.c)
+
+target_link_libraries(fuzz_tx_parser PUBLIC radix)
+target_compile_options(fuzz_tx_parser PUBLIC -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined)
+target_link_options(fuzz_tx_parser PUBLIC -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined)
+
+target_link_libraries(fuzz_bip32_path PUBLIC radix)
+target_compile_options(fuzz_bip32_path PUBLIC -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined)
+target_link_options(fuzz_bip32_path PUBLIC -fsanitize=fuzzer,address,undefined -fno-sanitize-recover=undefined)

--- a/fuzz/build.sh
+++ b/fuzz/build.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+TARGETS="fuzz_tx_parser fuzz_bip32_path"
+SCRIPTDIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd)"
+BUILDDIR="$SCRIPTDIR/cmake-build-fuzz"
+
+# Compile fuzzer
+rm -rf "$BUILDDIR"
+mkdir "$BUILDDIR"
+cd "$BUILDDIR"
+
+cmake -DCMAKE_C_COMPILER=clang ..
+make clean
+make $TARGETS

--- a/fuzz/fuzz_bip32_path.c
+++ b/fuzz/fuzz_bip32_path.c
@@ -1,0 +1,18 @@
+#include <string.h>
+
+#include "../src/transaction/transaction_parser.h"
+
+#define MIN(a,b) (((a)<(b))?(a):(b))
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+
+    char output[UINT256_DEC_STRING_MAX_LENGTH] = {0};
+
+    bip32_path_t bip32_path = {0};
+    bip32_path.path_len = Size/4;
+    
+    memcpy(bip32_path.path, Data, MIN(MAX_BIP32_PATH * 4, Size));
+    bip32_path_format(&bip32_path, output, sizeof(output));
+    
+    return 0;
+}

--- a/fuzz/fuzz_tx_parser.c
+++ b/fuzz/fuzz_tx_parser.c
@@ -1,0 +1,175 @@
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "../src/transaction/transaction_parser.h"
+#include "../unit-tests/util/sha256.h"
+
+static SHA256_CTX sha256_ctx;
+
+uint8_t pub_key_bytes[PUBLIC_KEY_COMPRESSED_LEN];
+
+static bool always_derive_44_536_2_1_3(derived_public_key_t *key) {
+    key->address.address_type = RE_ADDRESS_PUBLIC_KEY;
+    memmove(key->address.public_key.compressed, pub_key_bytes, PUBLIC_KEY_COMPRESSED_LEN);
+    return true;
+}
+
+static void init_sha256_hasher() {
+    sha256_init(&sha256_ctx);
+}
+
+static bool update_sha256_hasher_hash(buffer_t *buf, bool final, uint8_t *out) {
+    sha256_update(&sha256_ctx, buf->ptr, buf->size);
+    if (final) {
+        sha256_final(&sha256_ctx, out);
+    }
+    return true;  // never fails
+}
+
+void *memmem(const void *haystack, size_t n1, const void *needle, size_t n2) {
+    const unsigned char *p1 = haystack;
+    const unsigned char *p2 = needle;
+
+    if (n2 == 0) return (void *) p1;
+    if (n2 > n1) return NULL;
+
+    const unsigned char *p3 = p1 + n1 - n2 + 1;
+    for (const unsigned char *p = p1; (p = memchr(p, *p2, p3 - p)) != NULL; p++) {
+        if (!memcmp(p, p2, n2)) return (void *) p;
+    }
+
+    return NULL;
+}
+
+// FROM: https://gist.github.com/vi/dd3b5569af8a26b97c8e20ae06e804cb
+void hex_to_bin(const char *str, uint8_t *bytes, size_t blen) {
+    uint8_t pos;
+    uint8_t idx0;
+    uint8_t idx1;
+
+    // mapping of ASCII characters to hex values
+    const uint8_t hashmap[] = {
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,  // 01234567
+        0x08, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // 89:;<=>?
+        0x00, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x00,  // @ABCDEFG
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,  // HIJKLMNO
+    };
+
+    memset(bytes, 0, blen);
+    for (pos = 0; ((pos < (blen * 2)) && (pos < strlen(str))); pos += 2) {
+        idx0 = ((uint8_t) str[pos + 0] & 0x1F) ^ 0x10;
+        idx1 = ((uint8_t) str[pos + 1] & 0x1F) ^ 0x10;
+        bytes[pos / 2] = (uint8_t) (hashmap[idx0] << 4) | hashmap[idx1];
+    };
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    hex_to_bin("0356959464545aa2787984fe4ac76496721a22f150c0076724ad7190fe3a597bb7",
+               pub_key_bytes,
+               PUBLIC_KEY_COMPRESSED_LEN);
+
+    // =============================================
+    // Split input into multiple instructions based on separator == "deadbeef"
+    // =============================================
+    uint8_t *haystack = (uint8_t*)Data;
+    size_t haystack_len = Size;
+    // sep = 0x 64 65 61 64 62 65 65 66 => deadbeef in ascii
+    const uint8_t separator[] = {0x64, 0x65, 0x61, 0x64, 0x62, 0x65, 0x65, 0x66};
+    int separator_len = 8;
+
+    int tx_byte_count = 0;
+    int total_number_of_instructions = 0;
+    const int max_splits = 500;
+    const int max_instruction_size = 5000;
+    uint8_t splits[max_splits][max_instruction_size];  // will never have more than 50 instructions
+    size_t split_sizes[max_splits];
+
+    while (1) {
+        uint8_t *separator_start = memmem(haystack, haystack_len, separator, separator_len);
+
+        if (separator_start != NULL) {
+            // compute index of where separator was found
+            int separator_index = separator_start - haystack;
+            size_t split_size = separator_index;
+
+            if (split_size > 0) {
+                memcpy(splits[total_number_of_instructions], haystack, split_size);
+
+                split_sizes[total_number_of_instructions] = split_size;
+                tx_byte_count += split_size;
+                total_number_of_instructions += 1;
+            }
+
+            // advance haystack to next part
+            haystack = haystack + separator_index + separator_len;
+            haystack_len -= (separator_index + separator_len);
+        } else {
+            break;
+        }
+    }
+
+    // if we didn't find any split, pass the whole input as a transaction
+    if (tx_byte_count == 0) {
+        tx_byte_count = Size;
+        total_number_of_instructions = 1;
+        memcpy(splits[0], Data, Size);
+        split_sizes[0] = Size;
+    }
+
+    // =============================================
+    // Init transaction metadata
+    // =============================================
+    transaction_parser_t tx_parser;
+    parse_and_process_instruction_outcome_t outcome;
+
+    memset(&tx_parser, 0, sizeof(tx_parser));
+
+    const bip32_path_t bip32_path = (bip32_path_t){
+        .path = {0x8000002C, 0x80000218, 0x80000002, 1, 3},
+        .path_len = 5,
+    };
+
+    transaction_metadata_t transaction_metadata = (transaction_metadata_t){
+        .tx_byte_count = tx_byte_count,
+        .tx_bytes_received_count = (uint32_t) 0,
+        .total_number_of_instructions = total_number_of_instructions,
+        .number_of_instructions_received = (uint16_t) 0,
+        .hrp_non_native_token = {0x00},
+        .hrp_non_native_token_len = (uint8_t) 0,
+    };
+
+    instruction_display_config_t ins_display_config = (instruction_display_config_t){
+        .display_substate_contents = true,
+        .display_tx_summary = true,
+    };
+
+    init_transaction_parser_config_t tx_parser_config = (init_transaction_parser_config_t){
+        .transaction_metadata = transaction_metadata,
+        .instruction_display_config = ins_display_config,
+        .bip32_path = bip32_path,
+    };
+
+    init_tx_parser_outcome_t init_tx_parser_outcome;
+
+    const bool init_tx_parser_successful = init_tx_parser_with_config(&tx_parser,
+                                                                      &always_derive_44_536_2_1_3,
+                                                                      &update_sha256_hasher_hash,
+                                                                      &init_sha256_hasher,
+                                                                      &tx_parser_config,
+                                                                      &init_tx_parser_outcome);
+    memset(&outcome, 0, sizeof(outcome));
+
+    // =============================================
+    // Parse each instruction
+    // =============================================
+    for (int i = 0; i < total_number_of_instructions; i++) {
+        buffer_t buf;
+        buf.offset = 0;
+        buf.size = split_sizes[i];
+        buf.ptr = splits[i];
+        parse_and_process_instruction_from_buffer(&buf, &tx_parser, &outcome);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
- Add fuzzers for transaction parser and BIP32 path.
- Enable fuzzing for 60 seconds in the CI for each PR or on demand. 
- No corpus given so far.